### PR TITLE
Portfolio Buttons fix

### DIFF
--- a/src/portfolio/PortfolioItem.jsx
+++ b/src/portfolio/PortfolioItem.jsx
@@ -10,18 +10,20 @@ export default function PortfolioItem(props) {
                     <h3 className="projTitle">{props.projTitle}</h3>
                     <p className="itemDescription">{props.itemDescription}</p>
                     <p className="techUsed">{props.techUsed}</p>
-                    <a className="portfolioItemButtonContainer" 
-                        href={props.siteLink} 
-                        target="_blank" 
-                        rel="noreferrer">
-                            <button className="buttonInterior">Live Site</button>
-                    </a>
-                    <a className="portfolioItemButtonContainer" 
-                        href={props.gitLink} 
-                        target="_blank" 
-                        rel="noreferrer">
-                            <button className="buttonInterior">Github Repo</button>
-                    </a>
+                    <div className="portfolioButtonsContainer">
+                        <a className="portfolioItemButtonContainer" 
+                            href={props.siteLink} 
+                            target="_blank" 
+                            rel="noreferrer">
+                                <button className="buttonInterior">Live Site</button>
+                        </a>
+                        <a className="portfolioItemButtonContainer" 
+                            href={props.gitLink} 
+                            target="_blank" 
+                            rel="noreferrer">
+                                <button className="buttonInterior">Github Repo</button>
+                        </a>
+                    </div>
                 </div>
         </div>
     )

--- a/src/portfolio/portfolio.css
+++ b/src/portfolio/portfolio.css
@@ -189,6 +189,10 @@
         font-style: italic;
         margin: 16px 0;
     }
+
+    .portfolioButtonsContainer {
+        display: flex;
+    }
     
     .portfolioItemButtonContainer {
         padding: 5px 10px;
@@ -210,7 +214,7 @@
         background-color: transparent;
         text-decoration: none;
         font-family: Chakra Petch;
-        font-size: 18px;
+        font-size: 14px;
         border: none;
         margin: 0;
         cursor: pointer;


### PR DESCRIPTION
Post deployment, found that portfolio item buttons would layer on top of eachother on iPhone 11. added flex container and reduced font size from 18-14 to fix.